### PR TITLE
Hotfix handle save todo

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "path": "^0.12.7",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
-    "react-hot-loader": "1.3.0",
+    "react-hot-loader": "^1.3.1",
     "react-router": "^3.0.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",

--- a/src/App.js
+++ b/src/App.js
@@ -84,9 +84,9 @@ class App extends Component {
         this.setState({ editing: id });
     }
     handleSaveTodo(id, newText) {
-        const prevTodos = this.state.todos;
-        const editIndex = prevTodos.findIndex(v=> v.id === id);
-        const newTodos = [...prevTodos];
+        const newTodos = [...this.state.todos];
+        const editIndex = newTodos.findIndex(v=> v.id === id);
+        const originText = newTodos[editIndex].text;
         newTodos[editIndex].text = newText;
         this.setState({
             todos: newTodos,
@@ -97,8 +97,10 @@ class App extends Component {
             url: `/${id}`,
             data: { text: newText },
             rej: err => {
+                console.log(err);
+                newTodos[editIndex].text = originText;
                 this.setState({
-                    todos: prevTodos
+                    todos: newTodos
                 });
             }
         });


### PR DESCRIPTION
기존 파일에서는 prevTodos를 얕은 복사해서 newTodos를 만들었습니다.
그리고 newTodos에서 특정 인덱스의 text를 수정했습니다.
하지만 얕은 복사라서 prevTodos의 내용에서도 바뀌는 바람에
DB 서버와 에러가 발생할 경우 기존 스테이트로 돌아가는 게 아니라
이미 적용된 스테이트가 계속 유지됩니다.
그리고 그냥 클론하고 npm i 후에 npm start 치면
react-hot-loader 모듈 관련 문제가 있어서 새로운 버전으로
의존성 관리를 하도록 수정했습니다.